### PR TITLE
Enhance tree toggle style

### DIFF
--- a/src/scripts/components/tree-node.vue
+++ b/src/scripts/components/tree-node.vue
@@ -107,7 +107,7 @@ li {
   justify-content: center;
   display: flex;
   align-items: center;
-  margin-top: 2px;
+  margin-top: 3px;
   color: white;
 }
 .tree-toggle:before {

--- a/src/scripts/components/tree-node.vue
+++ b/src/scripts/components/tree-node.vue
@@ -97,8 +97,8 @@ li {
 }
 .tree-toggle {
   cursor: pointer;
-  width: 15px;
-  height: 15px;
+  width: 16px;
+  height: 16px;
   margin-right: 5px;
   float: left;
   content: ' ';


### PR DESCRIPTION
# Summary
Adjust tree toggle button style.
It sets to equal tree toggle's child element heights. (+/- button and anchor tag)

# Preview
As-Is | To-Be
---|---
![image](https://user-images.githubusercontent.com/18328030/76683381-ff963780-6646-11ea-8094-33c56df21435.png) | ![image](https://user-images.githubusercontent.com/18328030/76683526-15f0c300-6648-11ea-92eb-abc9c9e74fd4.png)


