### PR TITLE
Fix input tag style

### DIFF
--- a/src/scripts/app.vue
+++ b/src/scripts/app.vue
@@ -108,7 +108,7 @@ input {
   width: 100%;
   height: 2.3em;
   border-radius: 3px;
-  border: solid 1px #BBB;
-  padding-left: 10px;
+  border: 1px solid #c1c7d0;
+  margin: 10px 0px;
 }
 </style>


### PR DESCRIPTION
# Summary

1. Set tree search input border color to confluence's default input border color.
2. Equalize search input's left and right margin.

# Preview

As-Is | To-Be
---|---
![image](https://user-images.githubusercontent.com/18328030/76684154-e3959480-664c-11ea-9446-3d4ab4c0b4ae.png) | ![image](https://user-images.githubusercontent.com/18328030/76684132-b47f2300-664c-11ea-8675-3452a3335f0a.png)
