### PR TITLE
add title attributes to link

### DIFF
--- a/src/scripts/components/tree-node.vue
+++ b/src/scripts/components/tree-node.vue
@@ -2,7 +2,7 @@
   <ul>
     <li v-if='isLinkVisible' >
       <div class='tree-toggle' :class='toggleStatus' @click.prevent='toggleSubTree'></div>
-      <a class='link' :class='toggleStatus' :href='url'>{{ linkText }}</a>
+      <a class='link' :class='toggleStatus' :title='linkText' :href='url'>{{ linkText }}</a>
     </li>
 
     <TreeNode v-show='isTreeVisible'


### PR DESCRIPTION
This helps when the page title is too long to appear in the side bar.
<img width="283" alt="Screen_Shot_2020-04-24_at_3_38_11_PM" src="https://user-images.githubusercontent.com/19767299/80182409-c687b480-8641-11ea-9536-f764d3216434.png">
